### PR TITLE
Rename decorators

### DIFF
--- a/example/flat_profiler.py
+++ b/example/flat_profiler.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from recompyle import shallow_call_profiler
+from recompyle import flat_profile
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def faster_function() -> None:
     time.sleep(0.001)
 
 
-@shallow_call_profiler(time_limit=0.3)
+@flat_profile(time_limit=0.3)
 def example_function(count: int) -> str:
     """Function we are rewriting to time calls."""
     faster_function()

--- a/example/wrap_calls.py
+++ b/example/wrap_calls.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
-from recompyle import rewrite_wrap_calls
+from recompyle import wrap_calls
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -21,7 +21,7 @@ def other_function(val: float) -> str:
     return f"other val: {val}"
 
 
-@rewrite_wrap_calls(wrap_call=basic_wrapper)
+@wrap_calls(wrapper=basic_wrapper)
 def example_function(count: int) -> str:
     """Function we are rewriting to wrap calls."""
     for _ in (int(v) for v in range(count)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 authors = [
     { name = "Daniel Wehr", email = "danwehr@gmail.com" },
 ]
-description = "Tools for modifying source at runtime. Shallow profiling of critical functions. Wrap all calls in a function."
+description = "Tools for modifying source at runtime. Flat profiling of critical functions. Wrap all calls in a function."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"

--- a/recompyle/__init__.py
+++ b/recompyle/__init__.py
@@ -1,4 +1,4 @@
 from recompyle.applied import shallow_call_profiler
-from recompyle.decorators import rewrite_wrap_calls
+from recompyle.decorators import rewrite_wrap_calls, wrap_calls
 
-__all__ = ["rewrite_wrap_calls", "shallow_call_profiler"]
+__all__ = ["rewrite_wrap_calls", "wrap_calls", "shallow_call_profiler"]

--- a/recompyle/__init__.py
+++ b/recompyle/__init__.py
@@ -1,4 +1,4 @@
-from recompyle.applied import shallow_call_profiler
+from recompyle.applied import flat_profile, shallow_call_profiler
 from recompyle.decorators import rewrite_wrap_calls, wrap_calls
 
-__all__ = ["rewrite_wrap_calls", "wrap_calls", "shallow_call_profiler"]
+__all__ = ["rewrite_wrap_calls", "wrap_calls", "flat_profile", "shallow_call_profiler"]

--- a/recompyle/applied/__init__.py
+++ b/recompyle/applied/__init__.py
@@ -1,4 +1,4 @@
 """Example tools that use recompyle features."""
-from recompyle.applied.shallow_profiler import shallow_call_profiler
+from recompyle.applied.flat_profiler import flat_profile, shallow_call_profiler
 
-__all__ = ["shallow_call_profiler"]
+__all__ = ["flat_profile", "shallow_call_profiler"]

--- a/recompyle/applied/flat_profiler.py
+++ b/recompyle/applied/flat_profiler.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import time
+import warnings
 from collections import defaultdict
 from collections.abc import Callable, Generator
 from operator import itemgetter
@@ -20,7 +21,7 @@ class ProfilerCallback(Protocol):
     """Profiler callback protocol."""
 
     def __call__(self, total: float, limit: float, times: TimeDict, func: Callable) -> None:
-        """Callback to run after function transformed with shallow_call_profiler is executed.
+        """Callback to run after the function transformed with flat_profile is executed.
 
         Args:
             total (float): Total execution time of the function.
@@ -68,7 +69,7 @@ def _find_name(call: Callable) -> str:
         return type(call).__name__
 
 
-def shallow_call_profiler(
+def flat_profile(
     *,
     time_limit: float,
     below_callback: ProfilerCallback | None = default_below_log,
@@ -93,6 +94,69 @@ def shallow_call_profiler(
         below_callback (ProfilerCallback | None): Called when execution time is under the time limit.
         above_callback (ProfilerCallback | None): Called when execution time is equal to or over the time limit.
     """
+    if below_callback is None and above_callback is None:
+        raise ValueError("At least one of before_callback and above_callback must be non-None")
+
+    _call_times: defaultdict[str, list[float]] = defaultdict(list)
+    _call_names: dict[object, str] = {}
+
+    def _get_name(call: Callable) -> str:
+        """Use stored callable name or find if the callable is new."""
+        try:
+            return _call_names[call]
+        except KeyError:
+            pass
+
+        _call_names[call] = _find_name(call)
+        return _call_names[call]
+
+    def _record_call_time(__call: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+        """Wrapper to record execution time of inner calls."""
+        start = time.perf_counter()
+        try:
+            return __call(*args, **kwargs)
+        finally:
+            end = time.perf_counter()
+            _call_times[_get_name(__call)].append(end - start)
+
+    def _measure_calls(func: Callable[P, T]) -> Callable[P, T]:
+        """Decorator to measure total call time and inner call times."""
+        _new_func = rewrite_wrap_calls_func(
+            target_func=func,
+            wrapper=_record_call_time,
+            decorator_name="flat_profile",
+        )
+
+        @functools.wraps(func)
+        def inner_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            start = time.perf_counter()
+            try:
+                return _new_func(*args, **kwargs)
+            finally:
+                duration = time.perf_counter() - start
+                if below_callback is not None and duration < time_limit:
+                    below_callback(duration, time_limit, _call_times.copy(), _new_func)
+                elif above_callback is not None and duration >= time_limit:
+                    above_callback(duration, time_limit, _call_times.copy(), _new_func)
+                _call_times.clear()
+
+        return inner_wrapper
+
+    return _measure_calls
+
+
+def shallow_call_profiler(
+    *,
+    time_limit: float,
+    below_callback: ProfilerCallback | None = default_below_log,
+    above_callback: ProfilerCallback | None = default_above_log,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Deprecated, use `recompyle.flat_profile` instead."""
+    warnings.warn(
+        "'shallow_call_profiler' has been renamed to 'flat_profile' as of 0.2.0. The old name will be removed in 0.3.0.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     if below_callback is None and above_callback is None:
         raise ValueError("At least one of before_callback and above_callback must be non-None")
 

--- a/recompyle/applied/shallow_profiler.py
+++ b/recompyle/applied/shallow_profiler.py
@@ -122,7 +122,7 @@ def shallow_call_profiler(
         """Decorator to measure total call time and inner call times."""
         _new_func = rewrite_wrap_calls_func(
             target_func=func,
-            wrap_call=_record_call_time,
+            wrapper=_record_call_time,
             decorator_name="shallow_call_profiler",
         )
 

--- a/recompyle/decorators/__init__.py
+++ b/recompyle/decorators/__init__.py
@@ -1,4 +1,4 @@
 """Collect decorators for easier importing."""
-from recompyle.decorators.decorate_function import rewrite_wrap_calls
+from recompyle.decorators.decorate_function import rewrite_wrap_calls, wrap_calls
 
-__all__ = ["rewrite_wrap_calls"]
+__all__ = ["rewrite_wrap_calls", "wrap_calls"]

--- a/recompyle/decorators/decorate_function.py
+++ b/recompyle/decorators/decorate_function.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
@@ -17,10 +18,39 @@ def rewrite_wrap_calls(
     whitelist: set[str] | None = None,
     rewrite_details: dict | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Deprecated, use `recompyle.wrap_calls` instead."""
+    warnings.warn(
+        "'rewrite_wrap_calls' has been renamed to 'wrap_calls' as of 0.2.0. The old name will be removed in 0.3.0.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+    def _call_wrapper(target_func: Callable[P, T]) -> Callable[P, T]:
+        return rewrite_wrap_calls_func(
+            target_func=target_func,
+            wrapper=wrap_call,
+            decorator_name="rewrite_wrap_calls",
+            ignore_builtins=ignore_builtins,
+            blacklist=blacklist,
+            whitelist=whitelist,
+            rewrite_details=rewrite_details,
+        )
+
+    return _call_wrapper
+
+
+def wrap_calls(
+    *,
+    wrapper: CallWrapper[WrapP],
+    ignore_builtins: bool = False,
+    blacklist: set[str] | None = None,
+    whitelist: set[str] | None = None,
+    rewrite_details: dict | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Apply `rewrite.rewrite_function.rewrite_wrap_calls_func` to decorated function.
 
     Args:
-        wrap_call (CallWrapper): Function or method that will wrap all calls inside target function.
+        wrapper (CallWrapper): Function or method that will wrap all calls inside target function.
         ignore_builtins (bool): Whether to skip wrapping builtin calls.
         blacklist (set[str] | None): Call names that should not be wrapped. String literal subscripts should not use
             quotes, e.g. use a name of `"a[b]"` to match code written as `a["b"]()`. Subscripts can be wildcards using an
@@ -36,8 +66,8 @@ def rewrite_wrap_calls(
     def _call_wrapper(target_func: Callable[P, T]) -> Callable[P, T]:
         return rewrite_wrap_calls_func(
             target_func=target_func,
-            wrap_call=wrap_call,
-            decorator_name="rewrite_wrap_calls",
+            wrapper=wrapper,
+            decorator_name="wrap_calls",
             ignore_builtins=ignore_builtins,
             blacklist=blacklist,
             whitelist=whitelist,

--- a/recompyle/performance.py
+++ b/recompyle/performance.py
@@ -1,7 +1,7 @@
 import timeit
 from statistics import mean
 
-from recompyle import shallow_call_profiler, wrap_calls
+from recompyle import flat_profile, wrap_calls
 
 
 def simple_wrapper(__call, *args, **kwargs):
@@ -39,7 +39,7 @@ def wrapped_simple():
     other(0, val2=1)
 
 
-@shallow_call_profiler(time_limit=100, below_callback=None)
+@flat_profile(time_limit=100, below_callback=None)
 def wrapped_profiler():
     other(0, val2=1)
     other(0, val2=1)
@@ -53,7 +53,7 @@ def wrapped_profiler():
     other(0, val2=1)
 
 
-@shallow_call_profiler(time_limit=100)  # Default below callback will always run
+@flat_profile(time_limit=100)  # Default below callback will always run
 def wrapped_profiler_below():
     other(0, val2=1)
     other(0, val2=1)
@@ -67,7 +67,7 @@ def wrapped_profiler_below():
     other(0, val2=1)
 
 
-@shallow_call_profiler(time_limit=0)  # Default above callback will always run
+@flat_profile(time_limit=0)  # Default above callback will always run
 def wrapped_profiler_above():
     other(0, val2=1)
     other(0, val2=1)
@@ -102,11 +102,11 @@ def collect_times(stmt, label):
 if __name__ == "__main__":
     base_avg_us = collect_times("unwrapped()", "unwrapped function")
     simple_avg_us = collect_times("wrapped_simple()", "simple wrapper")
-    profiler_avg_us = collect_times("wrapped_profiler()", "shallow profiler w/ no callback")
-    profiler_below_us = collect_times("wrapped_profiler_below()", "shallow profiler w/ default below callback")
-    profiler_above_us = collect_times("wrapped_profiler_above()", "shallow profiler w/ default above callback")
+    profiler_avg_us = collect_times("wrapped_profiler()", "flat profiler w/ no callback")
+    profiler_below_us = collect_times("wrapped_profiler_below()", "flat profiler w/ default below callback")
+    profiler_above_us = collect_times("wrapped_profiler_above()", "flat profiler w/ default above callback")
 
     print("\nSimple wrapper call cost is", (simple_avg_us - base_avg_us) / calls, "microseconds per wrapped call")
-    print("Shallow profiler call cost is", (profiler_avg_us - base_avg_us) / calls, "microseconds per wrapped call")
-    print("Shallow profiler default below callback costs", profiler_below_us - profiler_avg_us, "microseconds")
-    print("Shallow profiler default above callback costs", profiler_above_us - profiler_avg_us, "microseconds")
+    print("Flat profiler call cost is", (profiler_avg_us - base_avg_us) / calls, "microseconds per wrapped call")
+    print("Flat profiler default below callback costs", profiler_below_us - profiler_avg_us, "microseconds")
+    print("Flat profiler default above callback costs", profiler_above_us - profiler_avg_us, "microseconds")

--- a/recompyle/performance.py
+++ b/recompyle/performance.py
@@ -1,7 +1,7 @@
 import timeit
 from statistics import mean
 
-from recompyle import rewrite_wrap_calls, shallow_call_profiler
+from recompyle import shallow_call_profiler, wrap_calls
 
 
 def simple_wrapper(__call, *args, **kwargs):
@@ -25,7 +25,7 @@ def unwrapped():
     other(0, val2=1)
 
 
-@rewrite_wrap_calls(wrap_call=simple_wrapper)
+@wrap_calls(wrapper=simple_wrapper)
 def wrapped_simple():
     other(0, val2=1)
     other(0, val2=1)

--- a/recompyle/rewrite/rewrite_function.py
+++ b/recompyle/rewrite/rewrite_function.py
@@ -192,16 +192,16 @@ def rewrite_function(
 def rewrite_wrap_calls_func(
     *,
     target_func: Callable[P, T],
-    wrap_call: CallWrapper[WrapP],
+    wrapper: CallWrapper[WrapP],
     decorator_name: str | None = None,
     ignore_builtins: bool = False,
     blacklist: set[str] | None = None,
     whitelist: set[str] | None = None,
     rewrite_details: dict[str, object] | None = None,
 ) -> Callable[P, T]:
-    """Rewrites the target function so that every call is passed through the given `wrap_call`.
+    """Rewrites the target function so that every call is passed through the given `wrapper`.
 
-    The `wrap_call` must execute the call with its args and return the result of the call, much like a decorator. It
+    The `wrapper` must execute the call with its args and return the result of the call, much like a decorator. It
     will be passed into the rewritten target function through the keyword-only arg `_recompyle_wrap` which is added
     during the rewrite.
 
@@ -211,7 +211,7 @@ def rewrite_wrap_calls_func(
 
     Args:
         target_func (Callable): The function/method to rewrite.
-        wrap_call (CallWrapper): The function to pass all calls through.
+        wrapper (CallWrapper): The function to pass all calls through.
         decorator_name (str): The decorator name.
         ignore_builtins (bool): Whether to skip wrapping builtin calls.
         blacklist (set[str] | None): Call names that should not be wrapped. String literal subscripts should not use
@@ -236,7 +236,7 @@ def rewrite_wrap_calls_func(
     transformers: list[RecompyleBaseTransformer] = [
         WrapCallsTransformer(WRAP_NAME, decorator_name, blacklist=full_blacklist, whitelist=whitelist),
     ]
-    custom_locals: dict[str, object] = {WRAP_NAME: wrap_call}  # Provide ref for kwarg default through locals.
+    custom_locals: dict[str, object] = {WRAP_NAME: wrapper}  # Provide ref for kwarg default through locals.
 
     return rewrite_function(
         target_func=target_func,

--- a/tests/function/test_flat_profiler.py
+++ b/tests/function/test_flat_profiler.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 import pytest
 
-from recompyle import shallow_call_profiler
+from recompyle import flat_profile
 
 last_total: float = None
 last_limit: float = None
@@ -41,26 +41,26 @@ def delay_func(delay_time: float):
     time.sleep(delay_time)
 
 
-@shallow_call_profiler(time_limit=0.2, below_callback=get_args, above_callback=None)
+@flat_profile(time_limit=0.2, below_callback=get_args, above_callback=None)
 def custom_below_callback(delay_time: float):
     delay_func(delay_time)
     return sum(int(x) for x in range(3))
 
 
-@shallow_call_profiler(time_limit=0.2, below_callback=None, above_callback=get_args)
+@flat_profile(time_limit=0.2, below_callback=None, above_callback=get_args)
 def custom_above_callback(delay_time: float):
     delay_func(delay_time)
     return sum(int(x) for x in range(3))
 
 
-@shallow_call_profiler(time_limit=0.2)
+@flat_profile(time_limit=0.2)
 def default_callbacks(delay_time: float):
     delay_func(delay_time)
     return sum(int(x) for x in range(3))
 
 
 @pytest.mark.usefixtures("_wipe_args")
-class TestShallowCallProfiler:
+class TestFlatProfiler:
     def verify_callback_args(self, func_name, limit):
         """Helper function that checks all times were recorded that should have been."""
         delay_times = last_times.pop("delay_func")

--- a/tests/function/test_ignore_calls.py
+++ b/tests/function/test_ignore_calls.py
@@ -3,7 +3,7 @@ Tests/examples for call wrapping while limiting which calls get wrapped.
 """
 import logging
 
-from recompyle import rewrite_wrap_calls
+from recompyle import wrap_calls
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ def other_function():
     return
 
 
-@rewrite_wrap_calls(wrap_call=basic_wrapper, ignore_builtins=True)
+@wrap_calls(wrapper=basic_wrapper, ignore_builtins=True)
 def with_builtins():
     for _ in (int(v) for v in range(5)):
         pass
@@ -45,21 +45,21 @@ class A:
     b = [B()]
 
 
-@rewrite_wrap_calls(wrap_call=basic_wrapper, blacklist={"A", "a.b[0].c[c].c_2"})
+@wrap_calls(wrapper=basic_wrapper, blacklist={"A", "a.b[0].c[c].c_2"})
 def complex_blacklist():
     a = A()
     a.b[0].c["c"].c_1()
     return a.b[0].c["c"].c_2()
 
 
-@rewrite_wrap_calls(wrap_call=basic_wrapper, blacklist={"a.b[0].c[*].c_2"})
+@wrap_calls(wrapper=basic_wrapper, blacklist={"a.b[0].c[*].c_2"})
 def complex_blacklist_wildcard():
     a = A()
     a.b[0].c["c"].c_1()
     return a.b[0].c["c"].c_2()
 
 
-@rewrite_wrap_calls(wrap_call=basic_wrapper, whitelist={"a.b[0].c[*].c_1"})
+@wrap_calls(wrapper=basic_wrapper, whitelist={"a.b[0].c[*].c_1"})
 def complex_whitelist_wildcard():
     a = A()
     a.b[0].c["c"].c_1()

--- a/tests/function/test_rewrite_basic.py
+++ b/tests/function/test_rewrite_basic.py
@@ -5,7 +5,7 @@ import logging
 
 import pytest
 
-from recompyle import rewrite_wrap_calls
+from recompyle import wrap_calls
 
 log = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def basic_wrapper(__call, *args, **kwargs):
         log.info(f"After {__call.__qualname__}")
 
 
-@rewrite_wrap_calls(wrap_call=basic_wrapper)
+@wrap_calls(wrapper=basic_wrapper)
 def example_function(count, secondary):
     for _ in (int(v) for v in range(count)):
         pass
@@ -31,7 +31,7 @@ def secondary_function():
 
 
 class ExampleClass:
-    @rewrite_wrap_calls(wrap_call=basic_wrapper)
+    @wrap_calls(wrapper=basic_wrapper)
     def example_method(self, count, secondary):
         for _ in (int(v) for v in range(count)):
             pass
@@ -41,7 +41,7 @@ class ExampleClass:
         return True
 
     @classmethod
-    @rewrite_wrap_calls(wrap_call=basic_wrapper)
+    @wrap_calls(wrapper=basic_wrapper)
     def example_classmethod(cls, count, secondary):
         for _ in (int(v) for v in range(count)):
             pass
@@ -52,7 +52,7 @@ class ExampleClass:
         return True
 
     @staticmethod
-    @rewrite_wrap_calls(wrap_call=basic_wrapper)
+    @wrap_calls(wrapper=basic_wrapper)
     def example_staticmethod(count, secondary):
         for _ in (int(v) for v in range(count)):
             pass
@@ -64,7 +64,7 @@ class ExampleClass:
 
 
 def outer_nested():
-    @rewrite_wrap_calls(wrap_call=basic_wrapper)
+    @wrap_calls(wrapper=basic_wrapper)
     def inner_nested():
         return int(1.23)
 

--- a/tests/function/test_traceback.py
+++ b/tests/function/test_traceback.py
@@ -2,7 +2,7 @@ import traceback
 
 import pytest
 
-from recompyle import rewrite_wrap_calls
+from recompyle import wrap_calls
 
 
 def wrapper_with_exc(__call, *args, **kwargs):
@@ -21,18 +21,18 @@ def secondary_no_exc():
     pass
 
 
-@rewrite_wrap_calls(wrap_call=wrapper_with_exc)
+@wrap_calls(wrapper=wrapper_with_exc)
 def func_with_wrapper_exc():
     secondary_no_exc()
 
 
-@rewrite_wrap_calls(wrap_call=wrapper_no_exc)
+@wrap_calls(wrapper=wrapper_no_exc)
 def func_with_inner_exc():
     secondary_no_exc()
     raise ValueError("TestErr")
 
 
-@rewrite_wrap_calls(wrap_call=wrapper_no_exc)
+@wrap_calls(wrapper=wrapper_no_exc)
 def func_with_deeper_exc():
     secondary_with_exc()
 


### PR DESCRIPTION
Renaming decorators:
- `rewrite_wrap_calls` -> `wrap_calls`. The `wrap_call` parameter has been renamed to `wrapper` as well in the new version.
- `shallow_call_profiler` -> `flat_profile`

Old names are available but should show a deprecation warning in tools like pytest. Some files also renamed accordingly. 

Also renamed the `wrap_call` parameter to `wrapper` for `rewrite_wrap_calls_func`. It's very unlikely anyone is using that directly, just the two decorators above, so going to take the risk and do this rename without deprecation.

Resolves #11.