### PR TITLE
Handle calls within the names of other calls

### DIFF
--- a/recompyle/transformers/function.py
+++ b/recompyle/transformers/function.py
@@ -122,6 +122,8 @@ class WrapCallsTransformer(RemoveDecoratorTransformer):
                 return f"{self._build_name(next_node)}.{name}"
             case ast.Subscript(value=next_node, slice=inner):
                 return f"{self._build_name(next_node)}[{self._build_name(inner)}]"
+            case ast.Call(func=func):
+                return f"{self._build_name(func)}"
             case _:
                 raise TypeError(f"Unknown call node type: {type(node)}")
 


### PR DESCRIPTION
Resolves #17.

Filtering including an inner call would include the inner call's name without brackets. E.g. with the line `value.inner[get_index()].process()`, for whitelist/blacklist purposes full name of the inner call is simply `"get_index"` while the full name of the outer call would be `"value.inner[get_index].process"`.