### PR TITLE
Adding Python 3.12 to testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities"
 ]
@@ -45,7 +46,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args}"


### PR DESCRIPTION
Resolves #22.

Technically this was usable in 3.12 before (restrictions are >= 3.10), but 3.12 will now be explicitly listed in PyPi, and the test matrix includes 3.12 as well.