### PR TITLE
Keep decorator after rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,6 @@ The original function is actually transformed into this alternate form by Recomp
 4. After modification, the AST is compiled back into a Python *code* object and then executed, running the new function definition and creating a new callable function object.
 5. The new function is returned by the decorator, replacing the original function.
 
-Note also that in the rewritten version of the function above, the `wrap_calls` decorator is no longer present! If not removed, when we execute the new function definition in step 4 it would rerun the decorator and transform the function again, adding another layer of call wrapping and leading to an infinite recursion and exception on loading the module.
-
 
 ## Future Additions
 


### PR DESCRIPTION
Remove `RemoveDecoratorTransformer`, which had the purpose of removing the decorator used to trigger rewriting. This was necessary because after the transform when we `exec` the new source, it would run the decorator again and begin an infinite recursion of transforms.

Instead of editing the source to remove the decorator, this change will detect whether a function has already been transformed the second time the decorator runs, and just return the already-transformed function to prevent the recursion.