### PR TITLE
Line range and source string of wrapped call now provided to wrapper

### DIFF
--- a/example/wrap_calls.py
+++ b/example/wrap_calls.py
@@ -7,7 +7,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def basic_wrapper(__call: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+def basic_wrapper(__call: Callable[P, T], _, *args: P.args, **kwargs: P.kwargs) -> T:
     """Basic wrapper that prints before and after each call."""
     print(f"Before {__call.__qualname__}, args: {args}, kwargs: {kwargs}")
     try:

--- a/recompyle/__about__.py
+++ b/recompyle/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Daniel Wehr <danwehr@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/recompyle/__init__.py
+++ b/recompyle/__init__.py
@@ -1,3 +1,4 @@
 from recompyle.decorators import wrap_calls
+from recompyle.rewrite import CallExtras
 
-__all__ = ["wrap_calls"]
+__all__ = ["CallExtras", "wrap_calls"]

--- a/recompyle/decorators/decorate_function.py
+++ b/recompyle/decorators/decorate_function.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 

--- a/recompyle/rewrite/__init__.py
+++ b/recompyle/rewrite/__init__.py
@@ -1,4 +1,8 @@
 """Collect rewrite tools for easier importing."""
-from recompyle.rewrite.rewrite_function import CallWrapper, rewrite_wrap_calls_func
+from recompyle.rewrite.rewrite_function import (
+    CallExtras,
+    CallWrapper,
+    rewrite_wrap_calls_func,
+)
 
-__all__ = ["CallWrapper", "rewrite_wrap_calls_func"]
+__all__ = ["CallExtras", "CallWrapper", "rewrite_wrap_calls_func"]

--- a/tests/function/test_extras.py
+++ b/tests/function/test_extras.py
@@ -1,0 +1,46 @@
+import logging
+
+import pytest
+
+from recompyle import CallExtras, wrap_calls
+
+log = logging.getLogger(__name__)
+
+
+def basic_wrapper(__call, __extras: CallExtras, *args, **kwargs):
+    """Basic wrapper that creates two logs per call."""
+    log.info(f"{__extras['ln_range']} {__extras['source']}")
+    return __call(*args, **kwargs)
+
+
+def unrelated_decorator(func):
+    return func
+
+
+@unrelated_decorator
+@wrap_calls(wrapper=basic_wrapper)
+def example_function(count):
+    for v in range(count):
+        int(
+            v,
+        )
+
+
+# THE TESTS BELOW ARE FRAGILE TESTS AS WE ARE VERIFYING LINE NUMBERS
+# MOVING ANY LINES ABOVE WILL BREAK AT LEAST ONE TEST
+
+
+class TestWrapperExtras:
+    COUNT = 2
+
+    def test_wrap_extras(self, caplog):
+        with caplog.at_level(logging.INFO):
+            example_function(TestWrapperExtras.COUNT)
+
+        msgs = [log.message for log in caplog.records]
+        expected = [
+            "(23,) range(count)",
+            "(24, 26) int(v)",
+            "(24, 26) int(v)",
+        ]
+        assert msgs == expected

--- a/tests/function/test_ignore_calls.py
+++ b/tests/function/test_ignore_calls.py
@@ -8,7 +8,7 @@ from recompyle import wrap_calls
 log = logging.getLogger(__name__)
 
 
-def basic_wrapper(__call, *args, **kwargs):
+def basic_wrapper(__call, _, *args, **kwargs):
     """Basic wrapper that creates two logs per call."""
     log.info(f"Before {__call.__qualname__}")
     try:

--- a/tests/function/test_rewrite_basic.py
+++ b/tests/function/test_rewrite_basic.py
@@ -10,7 +10,7 @@ from recompyle import wrap_calls
 log = logging.getLogger(__name__)
 
 
-def basic_wrapper(__call, *args, **kwargs):
+def basic_wrapper(__call, _, *args, **kwargs):
     """Basic wrapper that creates two logs per call."""
     log.info(f"Before {__call.__qualname__}")
     try:

--- a/tests/function/test_traceback.py
+++ b/tests/function/test_traceback.py
@@ -5,11 +5,11 @@ import pytest
 from recompyle import wrap_calls
 
 
-def wrapper_with_exc(__call, *args, **kwargs):
+def wrapper_with_exc(__call, _, *args, **kwargs):
     raise ValueError("TestErr")
 
 
-def wrapper_no_exc(__call, *args, **kwargs):
+def wrapper_no_exc(__call, _, *args, **kwargs):
     return __call(*args, **kwargs)
 
 


### PR DESCRIPTION
Resolves #21.

During transformation to wrap calls, a dictionary will now be passed in as a 2nd argument to the wrapper. This holds both info on the line range of the call as well as a string of the original source. Though something like a tuple would be more efficient here, a dict was selected in case we need to add more extras at a later time.

Version updated to 0.4.0 as this will be the next release.